### PR TITLE
(Untested) Update Creategame from strawpoll data

### DIFF
--- a/src/frontend-scripts/components/section-main/Creategame.jsx
+++ b/src/frontend-scripts/components/section-main/Creategame.jsx
@@ -19,7 +19,7 @@ if (user) {
 export default class Creategame extends React.Component {
 	state = {
 		gameName: '',
-		sliderValues: [5, 10],
+		sliderValues: [7, 7],
 		experiencedmode: true,
 		disablechat: false,
 		disablegamechat: false,
@@ -1129,6 +1129,21 @@ export default class Creategame extends React.Component {
 									})()}
 								</span>
 							)}
+							<span
+								title="May glitch out - use with caution"
+								style={{
+									color: 'red',
+									position: 'absolute',
+									left: '-130px',
+									top: '40px'
+								}}
+							>
+								<i className="warning icon" style={{ color: 'red' }} />
+								Caution: <br />
+								May glitch out
+								<br />
+								Use with caution
+							</span>
 							<i className="big hourglass half icon" />
 							<h4 className="ui header">
 								Timed mode - if a player does not make an action after a certain amount of time, that action is completed for them randomly.


### PR DESCRIPTION
(Untested)

Secret Hitler Default Game Creation Settings
5: Display a warning that timed mode may be slightly buggy at the moment
6: Game mode slider starts set to 7p, adjustable
4: Observer chat on, can be ticked to off (current)
1: Rainbow box is ticked if you are rainbow, or unticked if you are grey
3: Elo slider can be set to your seasonal elo or overall elo
7: Keep 7p rebalanced mode (current)
2: Rebalanced box is ticked for 6p and 9p, but unticked for 7p


5 pulled from #1193 from @Vigasaurus